### PR TITLE
Added optional default header override to all public methods

### DIFF
--- a/KGSoft.TinyHttpClient.Tests/HttpRequestTests.cs
+++ b/KGSoft.TinyHttpClient.Tests/HttpRequestTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using KGSoft.TinyHttpClient.Tests.Model;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
@@ -11,6 +13,12 @@ namespace KGSoft.TinyHttpClient.Tests
     public class HttpRequestTests
     {
         const string ApiBase = "https://reqres.in/";
+        static AuthenticationHeaderValue authHeader = new AuthenticationHeaderValue("Bearer", "XYZ");
+        static Dictionary<string, string> customHeaders = new Dictionary<string, string>() { { "CustomKey", "CustomValue" } };
+
+        HeaderConfig cfgAuthHeader = new HeaderConfig() { AuthHeader = authHeader };
+        HeaderConfig cfgCustomHeaders = new HeaderConfig() { CustomHeaders = customHeaders };
+        HeaderConfig cfgFull = new HeaderConfig() { AuthHeader = authHeader, CustomHeaders = customHeaders };
 
         private void AssertResponse(Response response)
         {
@@ -27,6 +35,34 @@ namespace KGSoft.TinyHttpClient.Tests
         public async Task Test_GET()
         {
             AssertResponse(await Helper.GetAsync(ApiBase + "api/users/2"));
+        }
+
+        [TestMethod]
+        public async Task Test_GET_GlobalHeaders()
+        {
+            HttpConfig.CustomHeaders = customHeaders;
+            HttpConfig.DefaultAuthHeader = authHeader;
+            AssertResponse(await Helper.GetAsync(ApiBase + "api/users/2"));
+            HttpConfig.CustomHeaders.Clear();
+            HttpConfig.DefaultAuthHeader = null;
+        }
+
+        [TestMethod]
+        public async Task Test_GET_AuthHeader()
+        {
+            AssertResponse(await Helper.GetAsync(ApiBase + "api/users/2", config: cfgAuthHeader ));
+        }
+
+        [TestMethod]
+        public async Task Test_GET_CustomHeader()
+        {
+            AssertResponse(await Helper.GetAsync(ApiBase + "api/users/2", config: cfgCustomHeaders));
+        }
+
+        [TestMethod]
+        public async Task Test_GET_CustomHeadersAll()
+        {
+            AssertResponse(await Helper.GetAsync(ApiBase + "api/users/2", config: cfgFull));
         }
 
         [TestMethod]

--- a/KGSoft.TinyHttpClient/Config/HttpClientPool.cs
+++ b/KGSoft.TinyHttpClient/Config/HttpClientPool.cs
@@ -14,28 +14,9 @@ namespace KGSoft.TinyHttpClient.Config
                 if (_httpClient == null)
                 {
                     _httpClient = new HttpClient();
-
-                    if (HttpConfig.DefaultAuthHeader != null)
-                        _httpClient.DefaultRequestHeaders.Authorization = HttpConfig.DefaultAuthHeader;
-
-                    if (HttpConfig.CustomHeaders != null)
-                        foreach (var kvp in HttpConfig.CustomHeaders)
-                            _httpClient.DefaultRequestHeaders.Add(kvp.Key, kvp.Value);
-
-                    _httpClient.DefaultRequestHeaders.Accept.Add(
-                        new MediaTypeWithQualityHeaderValue(HttpConfig.MediaTypeHeader));
                 }
                 return _httpClient;
             }
-        }
-
-        /// <summary>
-        /// Since we're re-using a single HttpClient, this method allows us to reset our HttpClient in case we need to change any config
-        /// after HttpClient has been instatiated for the first time
-        /// </summary>
-        public static void Reset()
-        {
-            _httpClient = null;
         }
     }
 }

--- a/KGSoft.TinyHttpClient/Helper.cs
+++ b/KGSoft.TinyHttpClient/Helper.cs
@@ -13,25 +13,26 @@ namespace KGSoft.TinyHttpClient
         /// <summary>
         /// Create a GET request without expecting a type returned
         /// </summary>
-        /// <param name="url"></param>
-        /// <param name="body"></param>
-        /// <param name="tkn"></param>
+        /// <param name="url">The URL we want to make the request to</param>
+        /// <param name="tkn">The cancellation token we want to use with this request</param>
+        /// <param name="config">Configuration unique to this request. Used to override what is defined in HttpConfig</param>
         /// <returns></returns>
-        public static Task<Response> GetAsync(string url, CancellationToken tkn = default(CancellationToken))
+        public static Task<Response> GetAsync(string url, CancellationToken tkn = default(CancellationToken), HeaderConfig config = default(HeaderConfig))
         {
-            return MakeHttpRequest(url, HttpMethod.Get, string.Empty, tkn);
+            return MakeHttpRequest(url, HttpMethod.Get, string.Empty, tkn, config);
         }
 
         /// <summary>
         /// Create a GET request expecting T in the response
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="url"></param>
-        /// <param name="tkn"></param>
+        /// <param name="url">The URL we want to make the request to</param>
+        /// <param name="tkn">The cancellation token we want to use with this request</param>
+        /// <param name="config">Configuration unique to this request. Used to override what is defined in HttpConfig</param>
         /// <returns></returns>
-        public static Task<Response<T>> GetAsync<T>(string url, CancellationToken tkn = default(CancellationToken))
+        public static Task<Response<T>> GetAsync<T>(string url, CancellationToken tkn = default(CancellationToken), HeaderConfig config = default(HeaderConfig))
         {
-            return MakeHttpRequest<T>(url, HttpMethod.Get, string.Empty, tkn);
+            return MakeHttpRequest<T>(url, HttpMethod.Get, string.Empty, tkn, config);
         }
         #endregion
 
@@ -39,26 +40,28 @@ namespace KGSoft.TinyHttpClient
         /// <summary>
         /// Create a POST request without expecting a type returned
         /// </summary>
-        /// <param name="url"></param>
-        /// <param name="body"></param>
-        /// <param name="tkn"></param>
+        /// <param name="url">The URL we want to make the request to</param>
+        /// <param name="body">The body we are sending with the request</param>
+        /// <param name="tkn">The cancellation token we want to use with this request</param>
+        /// <param name="config">Configuration unique to this request. Used to override what is defined in HttpConfig</param>
         /// <returns></returns>
-        public static Task<Response> PostAsync(string url, string body, CancellationToken tkn = default(CancellationToken))
+        public static Task<Response> PostAsync(string url, string body, CancellationToken tkn = default(CancellationToken), HeaderConfig config = default(HeaderConfig))
         {
-            return MakeHttpRequest(url, HttpMethod.Post, body, tkn);
+            return MakeHttpRequest(url, HttpMethod.Post, body, tkn, config);
         }
 
         /// <summary>
         /// Create a POST request expecting T in the response
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="url"></param>
-        /// <param name="body"></param>
-        /// <param name="tkn"></param>
+        /// <param name="url">The URL we want to make the request to</param>
+        /// <param name="body">The body we are sending with the request</param>
+        /// <param name="tkn">The cancellation token we want to use with this request</param>
+        /// <param name="config">Configuration unique to this request. Used to override what is defined in HttpConfig</param>
         /// <returns></returns>
-        public static Task<Response<T>> PostAsync<T>(string url, string body, CancellationToken tkn = default(CancellationToken))
+        public static Task<Response<T>> PostAsync<T>(string url, string body, CancellationToken tkn = default(CancellationToken), HeaderConfig config = default(HeaderConfig))
         {
-            return MakeHttpRequest<T>(url, HttpMethod.Post, body, tkn);
+            return MakeHttpRequest<T>(url, HttpMethod.Post, body, tkn, config);
         }
         #endregion
 
@@ -66,26 +69,28 @@ namespace KGSoft.TinyHttpClient
         /// <summary>
         /// Create a PUT request without expecting a type returned
         /// </summary>
-        /// <param name="url"></param>
-        /// <param name="body"></param>
-        /// <param name="tkn"></param>
+        /// <param name="url">The URL we want to make the request to</param>
+        /// <param name="body">The body we are sending with the request</param>
+        /// <param name="tkn">The cancellation token we want to use with this request</param>
+        /// <param name="config">Configuration unique to this request. Used to override what is defined in HttpConfig</param>
         /// <returns></returns>
-        public static Task<Response> PutAsync(string url, string body, CancellationToken tkn = default(CancellationToken))
+        public static Task<Response> PutAsync(string url, string body, CancellationToken tkn = default(CancellationToken), HeaderConfig config = default(HeaderConfig))
         {
-            return MakeHttpRequest(url, HttpMethod.Put, body, tkn);
+            return MakeHttpRequest(url, HttpMethod.Put, body, tkn, config);
         }
 
         /// <summary>
         /// Create a PUT request expecting T in the response 
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="url"></param>
-        /// <param name="body"></param>
-        /// <param name="tkn"></param>
+        /// <param name="url">The URL we want to make the request to</param>
+        /// <param name="body">The body we are sending with the request</param>
+        /// <param name="tkn">The cancellation token we want to use with this request</param>
+        /// <param name="config">Configuration unique to this request. Used to override what is defined in HttpConfig</param>
         /// <returns></returns>
-        public static Task<Response<T>> PutAsync<T>(string url, string body, CancellationToken tkn = default(CancellationToken))
+        public static Task<Response<T>> PutAsync<T>(string url, string body, CancellationToken tkn = default(CancellationToken), HeaderConfig config = default(HeaderConfig))
         {
-            return MakeHttpRequest<T>(url, HttpMethod.Put, body, tkn);
+            return MakeHttpRequest<T>(url, HttpMethod.Put, body, tkn, config);
         }
         #endregion
 
@@ -93,25 +98,25 @@ namespace KGSoft.TinyHttpClient
         /// <summary>
         /// Create a DELETE request without expecting a type returned
         /// </summary>
-        /// <param name="url"></param>
-        /// <param name="body"></param>
-        /// <param name="tkn"></param>
+        /// <param name="url">The URL we want to make the request to</param>
+        /// <param name="tkn">The cancellation token we want to use with this request</param>
+        /// <param name="config">Configuration unique to this request. Used to override what is defined in HttpConfig</param>
         /// <returns></returns>
-        public static Task<Response> DeleteAsync(string url, CancellationToken tkn = default(CancellationToken))
+        public static Task<Response> DeleteAsync(string url, CancellationToken tkn = default(CancellationToken), HeaderConfig config = default(HeaderConfig))
         {
-            return MakeHttpRequest(url, HttpMethod.Delete, string.Empty, tkn);
+            return MakeHttpRequest(url, HttpMethod.Delete, string.Empty, tkn, config);
         }
 
         /// <summary>
         /// Create a DELETE request expecting T in the response
         /// </summary>
-        /// <param name="url"></param>
-        /// <param name="body"></param>
-        /// <param name="tkn"></param>
+        /// <param name="url">The URL we want to make the request to</param>
+        /// <param name="tkn">The cancellation token we want to use with this request</param>
+        /// <param name="config">Configuration unique to this request. Used to override what is defined in HttpConfig</param>
         /// <returns></returns>
-        public static Task<Response<T>> DeleteAsync<T>(string url, CancellationToken tkn = default(CancellationToken))
+        public static Task<Response<T>> DeleteAsync<T>(string url, CancellationToken tkn = default(CancellationToken), HeaderConfig config = default(HeaderConfig))
         {
-            return MakeHttpRequest<T>(url, HttpMethod.Delete, string.Empty, tkn);
+            return MakeHttpRequest<T>(url, HttpMethod.Delete, string.Empty, tkn, config);
         }
         #endregion
 
@@ -121,14 +126,14 @@ namespace KGSoft.TinyHttpClient
         /// Used when we are expecing and actual type to come as a response that we need to deserialize
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="url"></param>
+        /// <param name="url">The URL we want to make the request to</param>
         /// <param name="method"></param>
         /// <param name="body"></param>
         /// <param name="tkn"></param>
         /// <returns></returns>
-        private static async Task<Response<T>> MakeHttpRequest<T>(string url, HttpMethod method, string body = "", CancellationToken tkn = default(CancellationToken))
+        private static async Task<Response<T>> MakeHttpRequest<T>(string url, HttpMethod method, string body = "", CancellationToken tkn = default(CancellationToken), HeaderConfig cfg = default(HeaderConfig))
         {
-            var message = await GetResponseMessage(url, method, body, tkn);
+            var message = await GetResponseMessage(url, method, body, tkn, cfg);
             var response = await message.BuildResponse<T>();
 
             HandleLogging(response);
@@ -139,14 +144,14 @@ namespace KGSoft.TinyHttpClient
         /// <summary>
         /// An HttpRequest with a hollow response. Used for things like Http.Delete where we do not expect to deserialize anything
         /// </summary>
-        /// <param name="url"></param>
+        /// <param name="url">The URL we want to make the request to</param>
         /// <param name="method"></param>
         /// <param name="body"></param>
         /// <param name="tkn"></param>
         /// <returns></returns>
-        private static async Task<Response> MakeHttpRequest(string url, HttpMethod method, string body = "", CancellationToken tkn = default(CancellationToken))
+        private static async Task<Response> MakeHttpRequest(string url, HttpMethod method, string body = "", CancellationToken tkn = default(CancellationToken), HeaderConfig cfg = default(HeaderConfig))
         {
-            var message = await GetResponseMessage(url, method, body, tkn);
+            var message = await GetResponseMessage(url, method, body, tkn, cfg);
             var response = await message.BuildResponse();
 
             HandleLogging(response);
@@ -178,16 +183,33 @@ namespace KGSoft.TinyHttpClient
         /// <summary>
         /// Create and send an HttpRequestMessage
         /// </summary>
-        /// <param name="url"></param>
+        /// <param name="url">The URL we want to make the request to</param>
         /// <param name="method"></param>
         /// <param name="body"></param>
         /// <param name="tkn"></param>
         /// <returns></returns>
-        private static async Task<HttpResponseMessage> GetResponseMessage(string url, HttpMethod method, string body = "", CancellationToken tkn = default(CancellationToken))
+        private static async Task<HttpResponseMessage> GetResponseMessage(string url, HttpMethod method, string body = "", CancellationToken tkn = default(CancellationToken), HeaderConfig cfg = default(HeaderConfig))
         {
             HttpRequestMessage request = new HttpRequestMessage(method, url);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(HttpConfig.MediaTypeHeader));
+
             LogHelper.LogMessage($"[{method.Method}]: {url}");
 
+            // Prepare the headers as per the config passed through
+            if (cfg?.AuthHeader == null && HttpConfig.DefaultAuthHeader != null)
+                request.Headers.Authorization = HttpConfig.DefaultAuthHeader;
+            else if (cfg?.AuthHeader != null)
+                request.Headers.Authorization = cfg.AuthHeader;
+
+            // Prepare the custom headers as per the config passed through
+            if (cfg?.CustomHeaders == null && HttpConfig.CustomHeaders != null)
+                foreach (var kvp in HttpConfig.CustomHeaders)
+                    request.Headers.Add(kvp.Key, kvp.Value);
+            else if (cfg?.CustomHeaders != null)
+                foreach (var kvp in cfg.CustomHeaders)
+                    request.Headers.Add(kvp.Key, kvp.Value);
+
+            // Prepare the body
             if (!string.IsNullOrEmpty(body))
                 request.Content = CreateContent(body);
             

--- a/KGSoft.TinyHttpClient/KGSoft.TinyHttpClient.csproj
+++ b/KGSoft.TinyHttpClient/KGSoft.TinyHttpClient.csproj
@@ -7,10 +7,13 @@
     <PackageProjectUrl>https://github.com/mr-kg/KGSoft.TinyHttpClient</PackageProjectUrl>
     <RepositoryUrl>https://github.com/mr-kg/KGSoft.TinyHttpClient</RepositoryUrl>
     <PackageTags>httpclient, restclient, netstandard, http-client, rest-api, rest-client</PackageTags>
-    <PackageReleaseNotes>Initial release</PackageReleaseNotes>
+    <PackageReleaseNotes>Moved Http Header from HttpClient to HttpRequestMessage, allowing more flexibility when calling different APIs
+Added optional param: HeaderConfig to all requests
+Added unit tests around new functionality
+Fleshed out param annotations</PackageReleaseNotes>
     <PackageIconUrl>https://www.mr-kg.com/wp-content/uploads/2018/11/httphelper.jpg</PackageIconUrl>
     <Description>A lightweight, highly compatible .NET Standard library for simplifying the consumption of REST APIs</Description>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/KGSoft.TinyHttpClient/Model/HeaderConfig.cs
+++ b/KGSoft.TinyHttpClient/Model/HeaderConfig.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Net.Http.Headers;
+
+namespace KGSoft.TinyHttpClient
+{
+    public class HeaderConfig
+    {
+        /// <summary>
+        /// The AuthHeader to use for this request
+        /// </summary>
+        public AuthenticationHeaderValue AuthHeader = null;
+        /// <summary>
+        /// The CustomHeaders to use for this request
+        /// </summary>
+        public Dictionary<string, string> CustomHeaders = null;
+    }
+}


### PR DESCRIPTION
Moved Http Header from HttpClient to HttpRequestMessage, allowing more flexibility when calling different APIs
Added optional param: HeaderConfig to all requests
Added unit tests around new functionality
Fleshed out param annotations